### PR TITLE
Extend Array API compliance

### DIFF
--- a/docs/source/guides/array_api.rst
+++ b/docs/source/guides/array_api.rst
@@ -1,0 +1,246 @@
+Array API Compatibility
+=======================
+
+ezmsg-learn uses the `Array API standard <https://data-apis.org/array-api/latest/>`_
+to allow processors to operate on arrays from different backends — NumPy, CuPy,
+PyTorch, and others — without code changes.
+
+.. contents:: On this page
+   :local:
+   :depth: 2
+
+
+How It Works
+------------
+
+Modules that support the Array API derive the array namespace from their input
+data using ``array_api_compat.get_namespace()``:
+
+.. code-block:: python
+
+   from array_api_compat import get_namespace
+
+   def process(self, data):
+       xp = get_namespace(data)       # numpy, cupy, torch, etc.
+       result = xp.linalg.inv(data)   # dispatches to the right backend
+       return result
+
+This means that if you pass a CuPy array, all computation stays on the GPU.
+If you pass a NumPy array, it behaves exactly as before.
+
+Helper utilities from ``ezmsg.sigproc.util.array`` handle device placement
+and creation functions portably:
+
+- ``array_device(x)`` — returns the device of an array, or ``None``
+- ``xp_create(fn, *args, dtype=None, device=None)`` — calls creation
+  functions (``zeros``, ``eye``) with optional device
+- ``xp_asarray(xp, obj, dtype=None, device=None)`` — portable ``asarray``
+
+
+Module Compatibility
+--------------------
+
+The table below summarises the Array API status of each module.
+
+Fully compatible
+^^^^^^^^^^^^^^^^
+
+These modules perform all computation in the source array namespace.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 35 65
+
+   * - Module
+     - Notes
+   * - ``process.ssr``
+     - LRR / self-supervised regression. Full Array API.
+   * - ``model.cca``
+     - Incremental CCA. Replaced ``scipy.linalg.sqrtm`` with an
+       eigendecomposition-based inverse square root using only Array API ops.
+   * - ``process.rnn``
+     - PyTorch-native; operates on ``torch.Tensor`` throughout.
+
+Mostly compatible (with NumPy boundaries)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+These modules use the Array API for data manipulation but fall back to NumPy
+at specific points where a dependency requires it.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 25 35 40
+
+   * - Module
+     - NumPy boundary
+     - Reason
+   * - ``model.refit_kalman``
+     - ``_compute_gain()``
+     - ``scipy.linalg.solve_discrete_are`` has no Array API equivalent.
+       Matrices are converted to NumPy for the DARE solver, then converted back.
+   * - ``model.refit_kalman``
+     - ``refit()`` mutation loop
+     - Per-sample velocity remapping uses ``np.linalg.norm`` on small vectors
+       and scalar element assignment.
+   * - ``process.refit_kalman``
+     - Inherits boundaries from model
+     - State init and output arrays use the source namespace.
+   * - ``process.slda``
+     - ``predict_proba``
+     - sklearn ``LinearDiscriminantAnalysis`` requires NumPy input.
+   * - ``process.adaptive_linear_regressor``
+     - ``partial_fit`` / ``predict``
+     - sklearn and river models require NumPy / pandas input.
+   * - ``dim_reduce.adaptive_decomp``
+     - ``partial_fit`` / ``transform``
+     - sklearn ``IncrementalPCA`` and ``MiniBatchNMF`` require NumPy input.
+
+Not converted
+^^^^^^^^^^^^^
+
+These modules use NumPy directly. Conversion would provide little benefit
+because the underlying estimator is the bottleneck.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 25 75
+
+   * - Module
+     - Reason
+   * - ``process.linear_regressor``
+     - Thin wrapper around sklearn ``LinearModel.predict``.
+       Could be made compatible if sklearn's ``array_api_dispatch`` is enabled
+       (see below).
+   * - ``process.sgd``
+     - sklearn ``SGDClassifier`` has no Array API support.
+   * - ``process.sklearn``
+     - Generic wrapper for arbitrary models; cannot assume Array API support.
+   * - ``dim_reduce.incremental_decomp``
+     - Delegates to ``adaptive_decomp``; trivial numpy usage (``np.prod`` on
+       Python tuples).
+
+
+sklearn Array API Dispatch
+--------------------------
+
+scikit-learn 1.8+ has experimental support for Array API dispatch on a subset
+of estimators.  Two estimators used in ezmsg-learn are on the supported list:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 30 40
+
+   * - Estimator
+     - Used in
+     - Constraint
+   * - ``LinearDiscriminantAnalysis``
+     - ``process.slda``
+     - Requires ``solver="svd"`` (the ``"lsqr"`` solver with ``shrinkage``
+       is not supported)
+   * - ``Ridge``
+     - ``process.linear_regressor``
+     - Requires ``solver="svd"``
+
+To use dispatch, enable it before creating the estimator:
+
+.. code-block:: python
+
+   from sklearn import set_config
+   set_config(array_api_dispatch=True)
+
+.. warning::
+
+   - ``array_api_dispatch`` is marked **experimental** in sklearn.
+   - Solver constraints (``solver="svd"``) may produce slightly different
+     numerical results compared to other solvers.
+   - Enabling dispatch globally may affect other sklearn estimators in the
+     same process.
+   - ezmsg-learn does **not** enable dispatch by default.
+
+Estimators that do **not** support Array API dispatch:
+
+- ``IncrementalPCA``, ``MiniBatchNMF`` — only batch ``PCA`` is supported
+- ``SGDClassifier``, ``SGDRegressor``, ``PassiveAggressiveRegressor``
+- All river models
+
+
+Writing Array API Compatible Code
+----------------------------------
+
+When adding or modifying processors in ezmsg-learn, follow these patterns.
+
+Deriving the namespace
+^^^^^^^^^^^^^^^^^^^^^^
+
+Always derive ``xp`` from the input data, not from a hardcoded ``numpy``:
+
+.. code-block:: python
+
+   from array_api_compat import get_namespace
+   from ezmsg.sigproc.util.array import array_device, xp_create
+
+   def _process(self, message):
+       xp = get_namespace(message.data)
+       dev = array_device(message.data)
+
+Transposing matrices
+^^^^^^^^^^^^^^^^^^^^
+
+The Array API does not support ``.T``.  Use ``xp.linalg.matrix_transpose()``:
+
+.. code-block:: python
+
+   # Before (numpy-only)
+   result = A.T @ B
+
+   # After (Array API)
+   _mT = xp.linalg.matrix_transpose
+   result = _mT(A) @ B
+
+Creating arrays
+^^^^^^^^^^^^^^^
+
+Use ``xp_create`` to handle device placement portably:
+
+.. code-block:: python
+
+   # Before
+   I = np.eye(n)
+   z = np.zeros((m, n), dtype=np.float64)
+
+   # After
+   I = xp_create(xp.eye, n, device=dev)
+   z = xp_create(xp.zeros, (m, n), dtype=xp.float64, device=dev)
+
+Handling sklearn boundaries
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+When calling into sklearn (or other NumPy-only libraries), convert at the
+boundary and convert back:
+
+.. code-block:: python
+
+   from array_api_compat import is_numpy_array
+
+   # Convert to numpy for sklearn
+   X_np = np.asarray(X) if not is_numpy_array(X) else X
+   result_np = estimator.predict(X_np)
+
+   # Convert back to source namespace
+   result = xp.asarray(result_np) if not is_numpy_array(X) else result_np
+
+Checking for NaN
+^^^^^^^^^^^^^^^^
+
+Use ``xp.isnan`` instead of ``np.isnan``:
+
+.. code-block:: python
+
+   if xp.any(xp.isnan(message.data)):
+       return
+
+Norms
+^^^^^
+
+Use ``xp.linalg.matrix_norm`` (Frobenius by default) instead of
+``np.linalg.norm`` for matrices.  For vectors, use ``xp.linalg.vector_norm``.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -54,6 +54,7 @@ For general ezmsg tutorials and guides, visit `ezmsg.org <https://www.ezmsg.org>
    :caption: Contents:
 
    guides/classification
+   guides/array_api
    api/index
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,8 +9,9 @@ license = "MIT"
 requires-python = ">=3.10.15"
 dynamic = ["version"]
 dependencies = [
-    "ezmsg-baseproc>=1.4.0",
-    "ezmsg-sigproc>=2.15.0",
+    "ezmsg>=3.7.3",
+    "ezmsg-baseproc>=1.5.1",
+    "ezmsg-sigproc>=2.17.0",
     "river>=0.22.0",
     "scikit-learn>=1.6.0",
     "torch>=2.6.0",
@@ -74,4 +75,3 @@ known-third-party = ["ezmsg", "ezmsg.baseproc", "ezmsg.sigproc"]
 [tool.uv.sources]
 # Uncomment to use development version of ezmsg from git
 #ezmsg = { git = "https://github.com/ezmsg-org/ezmsg.git", branch = "feature/profiling" }
-#ezmsg-sigproc = { path = "../ezmsg-sigproc", editable = true }

--- a/src/ezmsg/learn/model/cca.py
+++ b/src/ezmsg/learn/model/cca.py
@@ -1,5 +1,29 @@
+"""Incremental Canonical Correlation Analysis (CCA).
+
+.. note::
+    This module supports the Array API standard via
+    ``array_api_compat.get_namespace()``.  All linear algebra uses Array API
+    operations; ``scipy.linalg.sqrtm`` is replaced by an eigendecomposition-
+    based inverse square root (:func:`_inv_sqrtm_spd`).
+"""
+
 import numpy as np
-from scipy import linalg
+from array_api_compat import get_namespace
+from ezmsg.sigproc.util.array import array_device, xp_create
+
+
+def _inv_sqrtm_spd(xp, A):
+    """Inverse matrix square root for symmetric positive-definite matrices.
+
+    Computes ``inv(sqrtm(A)) = Q @ diag(1/sqrt(lambda)) @ Q^T`` using the
+    eigendecomposition.  This is more numerically stable than computing
+    ``inv(sqrtm(...))`` separately and uses only Array API operations.
+    """
+    eigenvalues, eigenvectors = xp.linalg.eigh(A)
+    eigenvalues = xp.clip(eigenvalues, 1e-12, None)  # avoid div-by-zero
+    inv_sqrt_eig = 1.0 / xp.sqrt(eigenvalues)
+    # Q @ diag(v) == Q * v (broadcasting), then @ Q^T
+    return (eigenvectors * inv_sqrt_eig) @ xp.linalg.matrix_transpose(eigenvectors)
 
 
 class IncrementalCCA:
@@ -33,39 +57,52 @@ class IncrementalCCA:
         self.adaptation_rate = adaptation_rate
         self.initialized = False
 
-    def initialize(self, d1, d2):
-        """Initialize the necessary matrices"""
+    def initialize(self, d1, d2, *, ref_array=None):
+        """Initialize the necessary matrices.
+
+        Args:
+            d1: Dimensionality of the first dataset.
+            d2: Dimensionality of the second dataset.
+            ref_array: Optional reference array to derive array namespace
+                and device from.  If ``None``, defaults to NumPy.
+        """
         self.d1 = d1
         self.d2 = d2
 
+        if ref_array is not None:
+            xp = get_namespace(ref_array)
+            dev = array_device(ref_array)
+        else:
+            xp, dev = np, None
+
         # Initialize correlation matrices
-        self.C11 = np.zeros((d1, d1))
-        self.C22 = np.zeros((d2, d2))
-        self.C12 = np.zeros((d1, d2))
+        self.C11 = xp_create(xp.zeros, (d1, d1), dtype=xp.float64, device=dev)
+        self.C22 = xp_create(xp.zeros, (d2, d2), dtype=xp.float64, device=dev)
+        self.C12 = xp_create(xp.zeros, (d1, d2), dtype=xp.float64, device=dev)
 
         self.initialized = True
 
     def _compute_change_magnitude(self, C11_new, C22_new, C12_new):
-        """Compute magnitude of change in correlation structure"""
+        """Compute magnitude of change in correlation structure."""
+        xp = get_namespace(self.C11)
+
         # Frobenius norm of differences
-        diff11 = np.linalg.norm(C11_new - self.C11)
-        diff22 = np.linalg.norm(C22_new - self.C22)
-        diff12 = np.linalg.norm(C12_new - self.C12)
+        diff11 = xp.linalg.matrix_norm(C11_new - self.C11)
+        diff22 = xp.linalg.matrix_norm(C22_new - self.C22)
+        diff12 = xp.linalg.matrix_norm(C12_new - self.C12)
 
         # Normalize by matrix sizes
-        diff11 /= self.d1 * self.d1
-        diff22 /= self.d2 * self.d2
-        diff12 /= self.d1 * self.d2
+        diff11 = diff11 / (self.d1 * self.d1)
+        diff22 = diff22 / (self.d2 * self.d2)
+        diff12 = diff12 / (self.d1 * self.d2)
 
-        return (diff11 + diff22 + diff12) / 3
+        return float((diff11 + diff22 + diff12) / 3)
 
     def _adapt_smoothing(self, change_magnitude):
-        """Adapt smoothing factor based on detected changes"""
+        """Adapt smoothing factor based on detected changes."""
         # If change is large, decrease smoothing factor
         target_smoothing = self.base_smoothing * (1.0 - change_magnitude)
-        target_smoothing = np.clip(
-            target_smoothing, self.min_smoothing, self.max_smoothing
-        )
+        target_smoothing = max(self.min_smoothing, min(target_smoothing, self.max_smoothing))
 
         # Smooth the adaptation itself
         self.current_smoothing = (
@@ -73,18 +110,21 @@ class IncrementalCCA:
         ) * self.current_smoothing + self.adaptation_rate * target_smoothing
 
     def partial_fit(self, X1, X2, update_projections=True):
-        """Update the model with new samples using adaptive smoothing
-        Assumes X1 and X2 are already centered and scaled"""
+        """Update the model with new samples using adaptive smoothing.
+        Assumes X1 and X2 are already centered and scaled."""
+        xp = get_namespace(X1, X2)
+        _mT = xp.linalg.matrix_transpose
+
         if not self.initialized:
-            self.initialize(X1.shape[1], X2.shape[1])
+            self.initialize(X1.shape[1], X2.shape[1], ref_array=X1)
 
         # Compute new correlation matrices from current batch
-        C11_new = X1.T @ X1 / X1.shape[0]
-        C22_new = X2.T @ X2 / X2.shape[0]
-        C12_new = X1.T @ X2 / X1.shape[0]
+        C11_new = _mT(X1) @ X1 / X1.shape[0]
+        C22_new = _mT(X2) @ X2 / X2.shape[0]
+        C12_new = _mT(X1) @ X2 / X1.shape[0]
 
         # Detect changes and adapt smoothing factor
-        if self.C11.any():  # Skip first update
+        if bool(xp.any(self.C11 != 0)):  # Skip first update
             change_magnitude = self._compute_change_magnitude(C11_new, C22_new, C12_new)
             self._adapt_smoothing(change_magnitude)
 
@@ -98,25 +138,26 @@ class IncrementalCCA:
             self._update_projections()
 
     def _update_projections(self):
-        """Update canonical vectors and correlations"""
+        """Update canonical vectors and correlations."""
+        xp = get_namespace(self.C11)
+        dev = array_device(self.C11)
+        _mT = xp.linalg.matrix_transpose
+
         eps = 1e-8
-        C11_reg = self.C11 + eps * np.eye(self.d1)
-        C22_reg = self.C22 + eps * np.eye(self.d2)
+        C11_reg = self.C11 + eps * xp_create(xp.eye, self.d1, dtype=self.C11.dtype, device=dev)
+        C22_reg = self.C22 + eps * xp_create(xp.eye, self.d2, dtype=self.C22.dtype, device=dev)
 
-        K = (
-            linalg.inv(linalg.sqrtm(C11_reg))
-            @ self.C12
-            @ linalg.inv(linalg.sqrtm(C22_reg))
-        )
-        U, self.correlations_, V = linalg.svd(K)
+        inv_sqrt_C11 = _inv_sqrtm_spd(xp, C11_reg)
+        inv_sqrt_C22 = _inv_sqrtm_spd(xp, C22_reg)
 
-        self.x_weights_ = linalg.inv(linalg.sqrtm(C11_reg)) @ U[:, : self.n_components]
-        self.y_weights_ = (
-            linalg.inv(linalg.sqrtm(C22_reg)) @ V.T[:, : self.n_components]
-        )
+        K = inv_sqrt_C11 @ self.C12 @ inv_sqrt_C22
+        U, self.correlations_, Vh = xp.linalg.svd(K, full_matrices=False)
+
+        self.x_weights_ = inv_sqrt_C11 @ U[:, : self.n_components]
+        self.y_weights_ = inv_sqrt_C22 @ _mT(Vh)[:, : self.n_components]
 
     def transform(self, X1, X2):
-        """Project data onto canonical components"""
+        """Project data onto canonical components."""
         X1_proj = X1 @ self.x_weights_
         X2_proj = X2 @ self.y_weights_
         return X1_proj, X2_proj

--- a/tests/unit/test_cca.py
+++ b/tests/unit/test_cca.py
@@ -1,0 +1,125 @@
+import numpy as np
+import pytest
+
+from ezmsg.learn.model.cca import IncrementalCCA, _inv_sqrtm_spd
+
+
+@pytest.fixture
+def rng():
+    return np.random.default_rng(42)
+
+
+@pytest.fixture
+def synthetic_data(rng):
+    """Create correlated synthetic data for CCA testing."""
+    n_samples, d1, d2 = 100, 5, 4
+    # Shared latent factor
+    latent = rng.standard_normal((n_samples, 2))
+    X1 = latent @ rng.standard_normal((2, d1)) + 0.1 * rng.standard_normal((n_samples, d1))
+    X2 = latent @ rng.standard_normal((2, d2)) + 0.1 * rng.standard_normal((n_samples, d2))
+    return X1, X2
+
+
+def test_initialize():
+    """Test that initialize creates matrices with correct shapes."""
+    cca = IncrementalCCA(n_components=2)
+    cca.initialize(5, 4)
+
+    assert cca.C11.shape == (5, 5)
+    assert cca.C22.shape == (4, 4)
+    assert cca.C12.shape == (5, 4)
+    assert cca.initialized is True
+    assert cca.d1 == 5
+    assert cca.d2 == 4
+
+
+def test_initialize_with_ref_array():
+    """Test that initialize respects ref_array namespace."""
+    ref = np.zeros(3)
+    cca = IncrementalCCA(n_components=2)
+    cca.initialize(5, 4, ref_array=ref)
+
+    assert cca.C11.shape == (5, 5)
+    assert cca.C11.dtype == np.float64
+
+
+def test_partial_fit(synthetic_data):
+    """Test that partial_fit runs without error and updates covariance."""
+    X1, X2 = synthetic_data
+    cca = IncrementalCCA(n_components=2)
+    cca.partial_fit(X1, X2)
+
+    assert cca.initialized is True
+    assert not np.allclose(cca.C11, 0)
+    assert not np.allclose(cca.C22, 0)
+    assert not np.allclose(cca.C12, 0)
+    assert hasattr(cca, "x_weights_")
+    assert hasattr(cca, "y_weights_")
+
+
+def test_partial_fit_incremental(synthetic_data):
+    """Test that multiple partial_fit calls update smoothly."""
+    X1, X2 = synthetic_data
+    cca = IncrementalCCA(n_components=2)
+
+    # First fit
+    cca.partial_fit(X1[:50], X2[:50])
+    C11_first = cca.C11.copy()
+
+    # Second fit should change covariance
+    cca.partial_fit(X1[50:], X2[50:])
+    assert not np.allclose(C11_first, cca.C11)
+
+
+def test_transform(synthetic_data):
+    """Test that transform produces correct output shapes."""
+    X1, X2 = synthetic_data
+    cca = IncrementalCCA(n_components=2)
+    cca.partial_fit(X1, X2)
+
+    X1_proj, X2_proj = cca.transform(X1, X2)
+    assert X1_proj.shape == (100, 2)
+    assert X2_proj.shape == (100, 2)
+
+
+def test_transform_single_component(synthetic_data):
+    """Test with a single canonical component."""
+    X1, X2 = synthetic_data
+    cca = IncrementalCCA(n_components=1)
+    cca.partial_fit(X1, X2)
+
+    X1_proj, X2_proj = cca.transform(X1, X2)
+    assert X1_proj.shape == (100, 1)
+    assert X2_proj.shape == (100, 1)
+
+
+def test_numerical_equivalence_inv_sqrtm():
+    """Compare eigh-based _inv_sqrtm_spd with scipy.linalg on known SPD matrices."""
+    scipy_linalg = pytest.importorskip("scipy.linalg")
+
+    rng = np.random.default_rng(123)
+    # Create a known SPD matrix
+    A_raw = rng.standard_normal((5, 5))
+    A = A_raw.T @ A_raw + 0.1 * np.eye(5)  # Ensure SPD
+
+    # scipy reference
+    sqrtm_A = scipy_linalg.sqrtm(A)
+    inv_sqrtm_scipy = scipy_linalg.inv(np.real(sqrtm_A))
+
+    # Our implementation
+    inv_sqrtm_eigh = _inv_sqrtm_spd(np, A)
+
+    np.testing.assert_allclose(inv_sqrtm_eigh, inv_sqrtm_scipy, atol=1e-10)
+
+
+def test_correlations_are_computed(synthetic_data):
+    """Test that canonical correlations are stored after fit."""
+    X1, X2 = synthetic_data
+    cca = IncrementalCCA(n_components=2)
+    cca.partial_fit(X1, X2)
+
+    assert hasattr(cca, "correlations_")
+    assert len(cca.correlations_) >= 2
+    # Correlations should be between 0 and 1 for well-conditioned data
+    assert np.all(cca.correlations_[:2] >= 0)
+    assert np.all(cca.correlations_[:2] <= 1.0 + 1e-6)


### PR DESCRIPTION
## Summary

Extends Array API compliance across ezmsg-learn, following the pattern already established in `process/ssr.py`. This enables the same code to run on NumPy, CuPy, PyTorch, and other Array API-compatible backends via `array_api_compat.get_namespace()`.

### Phase 1: Kalman Filter (`model/refit_kalman.py`, `process/refit_kalman.py`)
- `fit()`, `predict()`, `update()`: All linear algebra now uses Array API (`xp.linalg.inv`, `xp.linalg.matrix_transpose`, `xp.linalg.pinv`, `xp_create(xp.eye, ...)`).
- `_compute_gain()`: DARE solver remains NumPy (no Array API equivalent for `scipy.linalg.solve_discrete_are`); results are converted back to the source namespace via `xp_asarray`.
- `refit()`: Per-sample mutation loop stays NumPy (small-vector `np.linalg.norm`, scalar indexing); final H/Q computation converted to xp.
- `_reset_state()` / `_process()`: Derive `xp`/`dev` from `message.data`; output arrays created with `xp_create`.
- Removed redundant `.copy()` calls (predict/update already return new arrays).

### Phase 2: Incremental CCA (`model/cca.py`)
- Replaced all `scipy.linalg.inv(scipy.linalg.sqrtm(...))` calls (4 occurrences) with `_inv_sqrtm_spd()` — an eigendecomposition-based inverse square root using only Array API ops (`eigh`, `clip`, `sqrt`, `@`, `matrix_transpose`).
- Removed `scipy.linalg` dependency entirely from this module.
- `np.linalg.norm` -> `xp.linalg.matrix_norm`, `np.clip(scalar)` -> Python `max(min(...))`, `.any()` -> `bool(xp.any(...))`.
- Added `ref_array` parameter to `initialize()` for namespace derivation.
- **New test file** `tests/unit/test_cca.py` with 8 tests including numerical equivalence validation against scipy.

### Phase 3: Tier 2 Processors
- **`process/slda.py`**: `np.moveaxis` -> `xp.permute_dims`; NumPy boundary before `sklearn.predict_proba`.
- **`process/adaptive_linear_regressor.py`**: `np.any(np.isnan(...))` -> `xp.any(xp.isnan(...))`, `np.moveaxis` -> `xp.permute_dims`; NumPy boundary before sklearn/river calls.
- **`dim_reduce/adaptive_decomp.py`**: `np.prod` -> `math.prod`, `.reshape` -> `xp.reshape`; NumPy boundary before sklearn `partial_fit`/`transform`, convert back to source namespace after transform.

### Not changed
- `process/rnn.py` (PyTorch-native)
- `process/sklearn.py` (generic wrapper, unknown models)
- `process/linear_regressor.py`, `process/sgd.py` (trivial: just `np.isnan` guard + sklearn call)

## Test plan
- [x] All 19 existing Kalman filter tests pass
- [x] All 4 existing SLDA tests pass
- [x] All 4 existing adaptive linear regressor tests pass
- [x] All 8 existing adaptive decomp tests pass
- [x] 8 new CCA tests pass (including `_inv_sqrtm_spd` vs `scipy.linalg.sqrtm` numerical equivalence)
- [x] Full suite: **277 passed**, 2 skipped (CUDA), 0 failures
