### PR TITLE
Fix LRR apply: detect block-diagonal clusters from the weight matrix

### DIFF
--- a/src/ezmsg/learn/process/ssr.py
+++ b/src/ezmsg/learn/process/ssr.py
@@ -420,11 +420,17 @@ class LRRTransformer(
         if self._state.affine is not None:
             self._state.affine.set_weights(effective)
         else:
+            # channel_clusters=None: let the affine detect blocks from the weight
+            # matrix itself. self._get_channel_clusters() can fall back to
+            # block_size here (cluster_by_field isn't resolved until a message
+            # arrives), and blocks finer than W's real ones make the block-diagonal
+            # matmul silently overwrite -- rereferencing each block against only
+            # part of its channels. W is the source of truth for its own blocks.
             self._state.affine = AffineTransformTransformer(
                 AffineTransformSettings(
                     weights=effective,
                     axis=self.settings.axis,
-                    channel_clusters=self._get_channel_clusters(n),
+                    channel_clusters=None,
                     min_cluster_size=self.settings.min_cluster_size,
                 )
             )

--- a/tests/unit/test_ssr.py
+++ b/tests/unit/test_ssr.py
@@ -38,6 +38,15 @@ def _random_data(n_times: int = 200, n_ch: int = 8, rng=None) -> np.ndarray:
     return rng.standard_normal((n_times, n_ch))
 
 
+def _common_mode_data(n_times: int = 400, n_ch: int = 8, rng=None) -> np.ndarray:
+    """Noise plus a shared common-mode component, so rereferencing (which
+    regresses out shared signal) produces a clearly non-identity output."""
+    if rng is None:
+        rng = np.random.default_rng(7)
+    common = rng.standard_normal((n_times, 1))
+    return rng.standard_normal((n_times, n_ch)) + common
+
+
 # ---------------------------------------------------------------------------
 # Tests
 # ---------------------------------------------------------------------------
@@ -442,13 +451,49 @@ class TestPrecalculatedWeightsFromFile:
         np.testing.assert_allclose(out.data, expected, atol=1e-10)
 
 
-def _common_mode_data(n_times: int = 400, n_ch: int = 8, rng=None) -> np.ndarray:
-    """Noise plus a shared common-mode component, so rereferencing (which
-    regresses out shared signal) produces a clearly non-identity output."""
-    if rng is None:
-        rng = np.random.default_rng(7)
-    common = rng.standard_normal((n_times, 1))
-    return rng.standard_normal((n_times, n_ch)) + common
+class TestApplyFollowsWeightBlocks:
+    """Regression: applying fit/loaded weights must equal ``X @ (I - W)`` no matter
+    what ``block_size`` / ``cluster_by_field`` the transformer carries.
+
+    The block-diagonal apply optimization must follow the WEIGHT MATRIX's real
+    block structure, not a cluster hint that may not match it. Previously the
+    affine was built with ``_get_channel_clusters()``, which falls back to
+    ``block_size`` when the ``cluster_by_field`` metadata is absent at apply time
+    (e.g. a processor constructed with weights before any message resolves the
+    field). When those fallback clusters were FINER than the W's true blocks --
+    as when a W is fit over non-contiguous electrode-array groups but applied with
+    a smaller ``block_size`` -- two input sub-groups of one true block mapped to
+    the same output indices, and the block-diagonal matmul's assignment silently
+    OVERWROTE the earlier sub-group. Each true block was then rereferenced against
+    only a subset of its channels, corrupting the output while looking valid.
+    """
+
+    def test_apply_ignores_block_size_finer_than_weight_blocks(self):
+        rng = np.random.default_rng(123)
+        n_ch = 128
+        # W block-diagonal over two NON-CONTIGUOUS 64-ch groups (like two electrode
+        # arrays interleaved in channel order: an "array" = two connector banks).
+        groups = [list(range(0, 32)) + list(range(96, 128)), list(range(32, 96))]
+        X = _random_data(n_times=600, n_ch=n_ch, rng=rng)
+
+        proc_fit = LRRTransformer(LRRSettings(channel_clusters=groups))
+        proc_fit.partial_fit(_make_axisarray(X))
+        W = proc_fit.state.weights.copy()
+        # W really is block-diagonal over the non-contiguous 64-ch groups.
+        for a in groups:
+            for b in groups:
+                if a is b:
+                    continue
+                np.testing.assert_array_equal(W[np.ix_(a, b)], 0.0)
+
+        # Apply the loaded W with block_size=32 (finer than the W's 64-ch blocks)
+        # and min_cluster_size=32 so the fallback clusters are NOT merged away.
+        # These 4x32 clusters do not match the W -> the block-diagonal apply used
+        # to silently overwrite. The result must still be the faithful X @ (I - W).
+        proc = LRRTransformer(LRRSettings(weights=W, block_size=32, min_cluster_size=32))
+        out = proc.send(_make_axisarray(X))
+        expected = X @ (np.eye(n_ch) - W)
+        np.testing.assert_allclose(out.data, expected, atol=1e-10)
 
 
 class TestLowChannelPassthrough:


### PR DESCRIPTION
## Summary
`LRRTransformer` could silently apply the wrong rereference when the fitted/loaded weight matrix is block-diagonal over clusters that don't match the transformer's `block_size` — most notably when `cluster_by_field` groups channels **non-contiguously** (e.g. an electrode array split across two connector banks). The decode/output looked valid but each block was rereferenced against only a subset of its channels.

## Root cause
`_on_weights_updated` built the internal `AffineTransform` with `channel_clusters=self._get_channel_clusters(n)`. That call runs when the weights are set — at construction for a pre-fit/loaded W, **before any message has arrived** — so `cluster_by_field` hasn't been resolved yet and it falls back to `block_size` clusters. When those fallback clusters are *finer* than the W's real blocks, two input sub-groups of one true block resolve to the **same** output indices. The affine's block-diagonal matmul writes with assignment (`result[out_idx] = chunk @ subW`, not `+=`), so the second sub-group **silently overwrites** the first — leaving each block rereferenced against only part of its channels. (Contiguous / matching clusters, e.g. bank-aligned, were unaffected, which is why this went unnoticed.) The cluster hint is only a performance optimization; it is not needed for correctness, since the weight matrix already encodes its own block structure.

## Fix
Pass `channel_clusters=None` so the affine auto-detects the block-diagonal structure directly from the weight matrix — the single source of truth — removing any fit/apply cluster mismatch. Auto-detection runs once at first build; adaptive weight updates reuse it via the in-place `set_weights` path, so there's no added per-update cost and the block-diagonal speedup is retained.

## Testing
New regression test `TestApplyFollowsWeightBlocks`: fits a W over two non-contiguous 64-ch groups, applies it with a mismatched `block_size=32`, and asserts the output equals `X @ (I − W)`. Fails on `main`, passes with this change. Full `tests/unit/test_ssr.py` suite (41 tests) passes.

## Follow-up?
`ezmsg-sigproc`'s `AffineTransform` will silently mis-computes for any caller that passes `channel_clusters` not matching the weights' nonzero structure. Should we add a PR there to validate/auto-correct/raise on a cluster–weight mismatch?